### PR TITLE
Update jpeg from 9d to 9e

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "9d" %}
+{% set version = "9e" %}
 
 package:
   name: jpeg
   version: {{ version }}
 
 source:
-  url: http://www.ijg.org/files/jpegsrc.v{{ version }}.tar.gz
-  md5: ad7e40dedc268f97c44e7ee3cd54548a
+  url: https://www.ijg.org/files/jpegsrc.v{{ version }}.tar.gz
+  sha256: 4077d6a6a75aeb01884f708919d25934c93305e49f7e3f36db9129320e6f4f3d
   patches:
     - CMakeLists.txt.patch  # [win]
 
@@ -31,9 +31,13 @@ test:
     - djpeg -dct int -ppm -outfile testout.ppm testorig.jpg
 
 about:
-  home: http://www.ijg.org/
-  license: Custom free software license
+  home: https://www.ijg.org/
+  license: IJG
+  license_file: README
+  license_family: Other
   summary: read/write jpeg COM, EXIF, IPTC medata
+  doc_url: https://www.ijg.org/files/
+  dev_url: https://www.ijg.org/files/
     
 extra:    
   recipe-maintainers:


### PR DESCRIPTION
# Changes

Changes:
- Set version to 9e
- Reset build number.
- Update license info, set doc_url and dev_url

# Review Information

## Source

https://www.ijg.org/files/

## License

https://www.ijg.org/files/ (README in the archive)

## Upstream Changes

https://www.ijg.org/files/ (change.log in the archive)

## Issues

NA

## Pins and Requireds

NA

## Testing

Existing tests passed.


# Closing Comments

jpeg build to 9e on all architectures

# Jira

https://anaconda.atlassian.net/browse/DSNC-3634