### PR TITLE
Rename static lib

### DIFF
--- a/recipe/CMakeLists.txt.patch
+++ b/recipe/CMakeLists.txt.patch
@@ -37,9 +37,9 @@
 +add_executable (wrjpgcom wrjpgcom.c)
 +target_link_libraries (wrjpgcom libjpeg)
 +
-+add_library(jpeg STATIC ${JPEG_SRC})
++add_library(jpeg-static STATIC ${JPEG_SRC})
 +
-+install(TARGETS libjpeg cjpeg djpeg jpegtran rdjpgcom wrjpgcom jpeg
++install(TARGETS libjpeg cjpeg djpeg jpegtran rdjpgcom wrjpgcom jpeg-static
 +  RUNTIME DESTINATION bin
 +  LIBRARY DESTINATION lib
 +  ARCHIVE DESTINATION lib)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - CMakeLists.txt.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # compatible within major version numbers
     # https://abi-laboratory.pro/tracker/timeline/libjpeg/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,9 +35,11 @@ test:
     - if not exist %PREFIX%/Library/lib/jpeg-static.lib exit 1  # [win]
     - if not exist %PREFIX%/Library/include/jpeglib.h exit 1  # [win]
     - test -f ${PREFIX}/lib/pkgconfig/libjpeg.pc  # [unix]
-    - test -f ${PREFIX}/lib/libjpeg.so  # [unix]
-    - test -f ${PREFIX}/lib/libjpeg.so.9  # [unix]
-    - test -f ${PREFIX}/lib/libjpeg.so.9.5.0  # [unix]
+    - test -f ${PREFIX}/lib/libjpeg.so  # [linux]
+    - test -f ${PREFIX}/lib/libjpeg.so.9  # [linux]
+    - test -f ${PREFIX}/lib/libjpeg.so.9.5.0  # [linux]
+    - test -f ${PREFIX}/lib/libjpeg.9.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libjpeg.dylib  # [osx]
     - test -f ${PREFIX}/include/jpeglib.h  # [unix]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,15 @@ test:
   commands:
     - djpeg -dct int -ppm -outfile testout.ppm testorig.jpg
     - if not exist %PREFIX%/Library/lib/pkgconfig/libjpeg.pc exit 1  # [win]
+    - if not exist %PREFIX%/Library/bin/libjpeg.dll exit 1  # [win]
+    - if not exist %PREFIX%/Library/lib/libjpeg.lib exit 1  # [win]
+    - if not exist %PREFIX%/Library/lib/jpeg-static.lib exit 1  # [win]
+    - if not exist %PREFIX%/Library/include/jpeglib.h exit 1  # [win]
     - test -f ${PREFIX}/lib/pkgconfig/libjpeg.pc  # [unix]
+    - test -f ${PREFIX}/lib/libjpeg.so  # [unix]
+    - test -f ${PREFIX}/lib/libjpeg.so.9  # [unix]
+    - test -f ${PREFIX}/lib/libjpeg.so.9.5.0  # [unix]
+    - test -f ${PREFIX}/include/jpeglib.h  # [unix]
 
 about:
   home: https://www.ijg.org/


### PR DESCRIPTION
Rename the static lib (`jpeg.lib` > `jpeg-static.lib`) to avoid accidentally linking the static library instead of the shared library.

I'm getting pretty tired of spotting windows builds that statically link to jpeg. I'd much prefer that our builds fail than that we statically link jpeg.

For the curious, the shared library is called `libjpeg` on all platforms, but the static library is call `libjpeg` only on Linux and macOS. On Windows it's called `jpeg`. So when projects pass `-ljpeg` to links, on Windows it'll link against the static library.

This patch should fix this once and for all.

I could also have disabled the static lib altogether but decided to leave it there for now.