### PR TITLE
Name the shared libraries on windows "jpeg"

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -18,4 +18,11 @@ cmake -G "NMake Makefiles"                     ^
 if errorlevel 1 exit /b 1
 cmake --build . --config Release --target INSTALL -- VERBOSE=1
 if errorlevel 1 exit /b 1
+
+REM This allows consuming build systems to use the -ljpeg option,
+REM which is also specified in the .pc file.
+REM the .dll remains called libjpeg.dll to ensure previously-built
+REM downstream packages don't fail at runtime.
+copy %PREFIX%\Library\lib\libjpeg.lib %PREFIX%\Library\lib\jpeg.lib
+
 popd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ test:
     - if not exist %PREFIX%/Library/lib/pkgconfig/libjpeg.pc exit 1  # [win]
     - if not exist %PREFIX%/Library/bin/libjpeg.dll exit 1  # [win]
     - if not exist %PREFIX%/Library/lib/libjpeg.lib exit 1  # [win]
+    - if not exist %PREFIX%/Library/lib/jpeg.lib exit 1  # [win]
     - if not exist %PREFIX%/Library/lib/jpeg-static.lib exit 1  # [win]
     - if not exist %PREFIX%/Library/include/jpeglib.h exit 1  # [win]
     - test -f ${PREFIX}/lib/pkgconfig/libjpeg.pc  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - CMakeLists.txt.patch  # [win]
 
 build:
-  number: 2
+  number: 3
   run_exports:
     # compatible within major version numbers
     # https://abi-laboratory.pro/tracker/timeline/libjpeg/


### PR DESCRIPTION
Torchvision [expects it to be called jpeg](https://github.com/pytorch/vision/blob/6043bc250768b129e90a5321e318c1d51ee48a5c/setup.py#L310), and the libjpeg.pc.in upstream, from which the pkg-config file is generated, contains the line `Libs: -L${libdir} -ljpeg`