### PR TITLE
jpeg 9f 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,6 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - libtool       # [unix]
-    - make          # [unix]
-    - m2-patch      # [win]
 test:
   files:
     - testorig.jpg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "9e" %}
+{% set version = "9f" %}
 
 package:
   name: jpeg
@@ -6,12 +6,12 @@ package:
 
 source:
   url: https://www.ijg.org/files/jpegsrc.v{{ version }}.tar.gz
-  sha256: 4077d6a6a75aeb01884f708919d25934c93305e49f7e3f36db9129320e6f4f3d
+  sha256: 04705c110cb2469caa79fb71fba3d7bf834914706e9641a4589485c1f832565b
   patches:                  # [win]
     - CMakeLists.txt.patch  # [win]
 
 build:
-  number: 3
+  number: 0
   run_exports:
     # compatible within major version numbers
     # https://abi-laboratory.pro/tracker/timeline/libjpeg/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ build:
 requirements:
   build:
     - cmake         # [win]
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - libtool       # [unix]
     - make          # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
     - test -f ${PREFIX}/lib/pkgconfig/libjpeg.pc  # [unix]
     - test -f ${PREFIX}/lib/libjpeg.so  # [linux]
     - test -f ${PREFIX}/lib/libjpeg.so.9  # [linux]
-    - test -f ${PREFIX}/lib/libjpeg.so.9.5.0  # [linux]
+    - test -f ${PREFIX}/lib/libjpeg.so.9.6.0  # [linux]
     - test -f ${PREFIX}/lib/libjpeg.9.dylib  # [osx]
     - test -f ${PREFIX}/lib/libjpeg.dylib  # [osx]
     - test -f ${PREFIX}/include/jpeglib.h  # [unix]


### PR DESCRIPTION
jpeg 9f 

**Destination channel:** Defaults

### Links

- [PKG-9506]
- dev_url:        https://www.ijg.org/files/tree/
- conda_forge:    https://github.com/conda-forge/jpeg-feedstock
- pypi:           https://pypi.org/project/jpeg/9f
- pypi inspector: https://inspector.pypi.io/project/jpeg/9f

### Explanation of changes:

- new version number


[PKG-9506]: https://anaconda.atlassian.net/browse/PKG-9506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ